### PR TITLE
Add AES stream codecs

### DIFF
--- a/lib/kryptonite/aes.ex
+++ b/lib/kryptonite/aes.ex
@@ -148,10 +148,10 @@ defmodule Kryptonite.AES do
   ## Examples
 
       iex> {key, iv} = {generate_key!(), Random.bytes!(16)}
-      iex> "This is a secret"
+      iex> 'This is a secret'
       ...>     |> stream_encrypt(key, iv)
       ...>     |> Enum.to_list()
-      ...>     |> is_list(cypher)
+      ...>     |> is_list()
       true
   """
   @spec stream_encrypt(Enumerable.t, key, iv) :: Enumerable.t

--- a/lib/kryptonite/aes.ex
+++ b/lib/kryptonite/aes.ex
@@ -143,13 +143,15 @@ defmodule Kryptonite.AES do
   end
 
   @doc """
-  Encrypt a stream using AES in CTR mode.
+  Encrypts a stream using AES in CTR mode.
 
   ## Examples
 
       iex> {key, iv} = {generate_key!(), Random.bytes!(16)}
-      iex> cypher = 'This is a secret' |> stream_encrypt(key, iv) |> Enum.to_list()
-      iex> is_list(cypher)
+      iex> "This is a secret"
+      ...>     |> stream_encrypt(key, iv)
+      ...>     |> Enum.to_list()
+      ...>     |> is_list(cypher)
       true
   """
   @spec stream_encrypt(Enumerable.t, key, iv) :: Enumerable.t
@@ -211,8 +213,13 @@ defmodule Kryptonite.AES do
 
       iex> {key, iv} = {generate_key!(), Random.bytes!(16)}
       iex> msg = "This is a secret..."
-      iex> cypher = msg |> String.to_charlist() |> stream_encrypt(key, iv) |> Enum.to_list()
-      iex> msg == cypher |> stream_decrypt(key, iv) |> Enum.to_list() |> :erlang.iolist_to_binary
+      iex> msg == msg
+      ...>     |> String.to_charlist()
+      ...>     |> stream_encrypt(key, iv)
+      ...>     |> Enum.to_list()
+      ...>     |> stream_decrypt(key, iv)
+      ...>     |> Enum.to_list()
+      ...>     |> :erlang.iolist_to_binary
       true
   """
   @spec stream_decrypt(Enumerable.t, key, iv) :: Enumerable.t

--- a/lib/kryptonite/aes.ex
+++ b/lib/kryptonite/aes.ex
@@ -154,13 +154,15 @@ defmodule Kryptonite.AES do
       ...>     |> is_list()
       true
   """
-  @spec stream_encrypt(Enumerable.t, key, iv) :: Enumerable.t
+  @spec stream_encrypt(Enumerable.t(), key, iv) :: Enumerable.t()
   def stream_encrypt(stream, key, iv) do
     acc0 = :crypto.stream_init(:aes_ctr, key, iv)
+
     reduce = fn elem, acc ->
       {acc, cypher} = :crypto.stream_encrypt(acc, elem |> List.wrap())
       {[cypher], acc}
     end
+
     Stream.transform(stream, acc0, reduce)
   end
 
@@ -222,13 +224,15 @@ defmodule Kryptonite.AES do
       ...>     |> :erlang.iolist_to_binary
       true
   """
-  @spec stream_decrypt(Enumerable.t, key, iv) :: Enumerable.t
+  @spec stream_decrypt(Enumerable.t(), key, iv) :: Enumerable.t()
   def stream_decrypt(stream, key, iv) do
     acc0 = :crypto.stream_init(:aes_ctr, key, iv)
+
     reduce = fn elem, acc ->
       {acc, cypher} = :crypto.stream_decrypt(acc, elem)
       {[cypher], acc}
     end
+
     Stream.transform(stream, acc0, reduce)
   end
 


### PR DESCRIPTION
When encoding (large files), working with binaries can rapidly kill the VM.

This patch adds 2 functions for encoding and decoding streams with AES (CTR mode)

For instance:
```elixir
alias Kryptonite.AES
{key, iv} = {AES.generate_key!(), Random.bytes!(16)}
File.write!("/tmp/mysecret.txt", "This is a secret")
File.stream!("./mysecret.txt") |> AES.stream_encrypt(key, iv) |> Stream.into(File.stream!("./mysecret.enc")) |> Stream.run()
"This is a secret" = File.stream!("./mysecret.enc") |> AES.stream_decrypt(key, iv) |> Enum.to_list() |> :erlang.iolist_to_binary
```